### PR TITLE
fix(#2693): fix typo

### DIFF
--- a/flake-modules/dev/list-plugins/default.nix
+++ b/flake-modules/dev/list-plugins/default.nix
@@ -32,7 +32,7 @@
             list-plugins --root-path ${self} > $out
           '';
 
-      devshells.default.commands = [
+      devShells.default.commands = [
         {
           name = "list-plugins";
           command = ''${lib.getExe config.packages.list-plugins} "$@"'';


### PR DESCRIPTION
Relates to: https://github.com/nix-community/nixvim/issues/2693